### PR TITLE
pyupgrade --py38-plus because python_requires = >=3.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
     rev: v2.3.0
     hooks:
     -   id: add-trailing-comma
-        args: [--py38-plus]
+        args: [--py36-plus]
 -   repo: https://github.com/asottile/pyupgrade
     rev: v3.1.0
     hooks:


### PR DESCRIPTION
Aligns with https://github.com/MarcoGorelli/auto-walrus/blob/main/setup.cfg#L20