### PR TITLE
Lint Python with ruff replacing flake8, autopep8, etc.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,29 +15,11 @@ repos:
     rev: v2.2.0
     hooks:
     -   id: setup-cfg-fmt
--   repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.0.277
     hooks:
-    -   id: flake8
--   repo: https://github.com/pre-commit/mirrors-autopep8
-    rev: v2.0.2
-    hooks:
-    -   id: autopep8
--   repo: https://github.com/asottile/reorder-python-imports
-    rev: v3.9.0
-    hooks:
-    -   id: reorder-python-imports
-        args: [--py38-plus]
--   repo: https://github.com/asottile/add-trailing-comma
-    rev: v2.4.0
-    hooks:
-    -   id: add-trailing-comma
-        args: [--py36-plus]
--   repo: https://github.com/asottile/pyupgrade
-    rev: v3.4.0
-    hooks:
-    -   id: pyupgrade
-        args: [--py38-plus]
+    - id: ruff
+      # args: [ --fix, --exit-non-zero-on-fix ]
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.3.0
     hooks:

--- a/auto_walrus.py
+++ b/auto_walrus.py
@@ -4,9 +4,7 @@ import argparse
 import ast
 import re
 import sys
-from typing import Iterable
-from typing import Sequence
-from typing import Tuple
+from typing import Iterable, Sequence, Tuple
 
 SEP_SYMBOLS = frozenset(('(', ')', ',', ':'))
 # name, lineno, col_offset, end_lineno, end_col_offset
@@ -241,15 +239,14 @@ def visit_function_def(
             _other_usages,
             names,
             in_body_vars,
+        ) and related_vars_are_unused(
+            related_vars,
+            _assignment[0],
+            sorted_names,
+            assignment_idx,
+            if_statement_idx,
         ):
-            if related_vars_are_unused(
-                related_vars,
-                _assignment[0],
-                sorted_names,
-                assignment_idx,
-                if_statement_idx,
-            ):
-                walrus.append((_assignment, _if_statement))
+            walrus.append((_assignment, _if_statement))
     return walrus
 
 

--- a/auto_walrus.py
+++ b/auto_walrus.py
@@ -4,7 +4,9 @@ import argparse
 import ast
 import re
 import sys
-from typing import Iterable, Sequence, Tuple
+from typing import Iterable
+from typing import Sequence
+from typing import Tuple
 
 SEP_SYMBOLS = frozenset(('(', ')', ',', ':'))
 # name, lineno, col_offset, end_lineno, end_col_offset

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,9 @@ ignore = ["S101"]
 line-length = 88  # Recommended: 88
 target-version = "py38"
 
+[tool.ruff.isort]
+force-single-line = true
+
 [tool.ruff.mccabe]
 max-complexity = 14  # Recommended: 10
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,76 @@
+[tool.ruff]
+select = [
+  "A",      # flake8-builtins
+  "AIR",    # Airflow
+  "ANN",    # flake8-annotations
+  "ARG",    # flake8-unused-arguments
+  "ASYNC",  # flake8-async
+  "B",      # flake8-bugbear
+  "BLE",    # flake8-blind-except
+  "C4",     # flake8-comprehensions
+  "C90",    # McCabe cyclomatic complexity
+  "COM",    # flake8-commas
+  "CPY",    # Copyright-related rules
+  "DJ",     # flake8-django
+  "DTZ",    # flake8-datetimez
+  "E",      # pycodestyle
+  "EM",     # flake8-errmsg
+  "ERA",    # eradicate
+  "EXE",    # flake8-executable
+  "F",      # Pyflakes
+  "FA",     # flake8-future-annotations
+  "FBT",    # flake8-boolean-trap
+  "FIX",    # flake8-fixme
+  "FLY",    # flynt
+  "G",      # flake8-logging-format
+  "I",      # isort
+  "ICN",    # flake8-import-conventions
+  "INP",    # flake8-no-pep420
+  "INT",    # flake8-gettext
+  "ISC",    # flake8-implicit-str-concat
+  "N",      # pep8-naming
+  "PERF",   # Perflint
+  "PGH",    # pygrep-hooks
+  "PIE",    # flake8-pie
+  "PL",     # Pylint
+  "PT",     # flake8-pytest-style
+  "PYI",    # flake8-pyi
+  "RET",    # flake8-return
+  "RSE",    # flake8-raise
+  "RUF",    # Ruff-specific rules
+  "S",      # flake8-bandit
+  "SIM",    # flake8-simplify
+  "SLF",    # flake8-self
+  "SLOT",   # flake8-slots
+  "T10",    # flake8-debugger
+  "T20",    # flake8-print
+  "TCH",    # flake8-type-checking
+  "TD",     # flake8-todos
+  "TID",    # flake8-tidy-imports
+  "TRY",    # tryceratops
+  "UP",     # pyupgrade
+  "W",      # pycodestyle
+  "YTT",    # flake8-2020
+  # "D",    # pydocstyle
+  # "NPY",  # NumPy-specific rules
+  # "PD",   # pandas-vet
+  # "PTH",  # flake8-use-pathlib
+  # "Q",    # flake8-quotes
+]
+ignore = ["S101"]
+line-length = 88  # Recommended: 88
+target-version = "py38"
+
+[tool.ruff.mccabe]
+max-complexity = 14  # Recommended: 10
+
+[tool.ruff.pylint]
+allow-magic-value-types = ["int", "str"]
+max-args = 5  # Recommended: 5
+max-branches = 15  # Recommended: 12
+max-returns = 6  # Recommended: 6
+max-statements = 50  # Recommended: 50
+
+[tool.ruff.per-file-ignores]
+"auto_walrus.py" = ["ARG001", "PERF203"]
+"tests/*" = ["INP001", "PT006"]

--- a/setup.py
+++ b/setup.py
@@ -1,2 +1,3 @@
 from setuptools import setup
+
 setup()


### PR DESCRIPTION
Ruff replaces `add-trailing-comma`, `autopep8`, `flake8`, and `reorder-python-imports`.

[Ruff](https://beta.ruff.rs/) supports [over 500 lint rules](https://beta.ruff.rs/docs/rules) and can be used to replace [Flake8](https://pypi.org/project/flake8/) (plus dozens of plugins), [isort](https://pypi.org/project/isort/), [pydocstyle](https://pypi.org/project/pydocstyle/), [yesqa](https://github.com/asottile/yesqa), [eradicate](https://pypi.org/project/eradicate/), [pyupgrade](https://pypi.org/project/pyupgrade/), and [autoflake](https://pypi.org/project/autoflake/), all while executing (in Rust) tens or hundreds of times faster than any individual tool.