### PR TITLE
pre-commit: additional_dependencies: tomli

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Sample `.pre-commit-config.yaml`:
     rev: 0.3.3
     hooks:
     -   id: auto-walrus
+        additional_dependencies:
+            - tomli
 ```
 
 ## Command-line example

--- a/utils/bump_version.py
+++ b/utils/bump_version.py
@@ -23,8 +23,8 @@ with open("pyproject.toml", "w", encoding="utf-8") as f:
 with open("README.md", encoding="utf-8") as f:
     content = f.read()
 content = content.replace(
-    f'rev: {old_version}',
-    f'rev: {version}',
+    f"rev: {old_version}",
+    f"rev: {version}",
 )
 with open("README.md", "w", encoding="utf-8") as f:
     f.write(content)


### PR DESCRIPTION
Python >= v3.11 includes [`tomllib`](https://docs.python.org/3/library/tomllib.html#module-tomllib) but earlier versions of Python will need this change.