### PR TITLE
pyproject.toml: dependencies = ['tomli; python_version<"3.11"']

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,9 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
+dependencies = [
+    'tomli; python_version<"3.11"',
+]
 
 [project.scripts]
 auto-walrus = "auto_walrus:main"

--- a/utils/bump_version.py
+++ b/utils/bump_version.py
@@ -23,8 +23,8 @@ with open("pyproject.toml", "w", encoding="utf-8") as f:
 with open("README.md", encoding="utf-8") as f:
     content = f.read()
 content = content.replace(
-    f'rev: {old_version}',
-    f'rev: {version}',
+    f"rev: {old_version}",
+    f"rev: {version}",
 )
 with open("README.md", "w", encoding="utf-8") as f:
     f.write(content)


### PR DESCRIPTION
https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html

An alternative to:
* #35