### PR TITLE
CLI: Require paths

### DIFF
--- a/auto_walrus.py
+++ b/auto_walrus.py
@@ -348,7 +348,7 @@ def _get_config(paths: list[pathlib.Path]) -> dict[str, Any]:
 
 def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover
     parser = argparse.ArgumentParser()
-    parser.add_argument("paths", nargs="*")
+    parser.add_argument("paths", nargs="+", metavar="path")
     parser.add_argument(
         "--files",
         help="Regex pattern with which to match files to include",

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -210,3 +210,10 @@ def test_project_in_subdirectory_that_would_be_ignored(project_dir: ProjectDirT)
     main([str(project_root)])
     for file in files:
         assert file.read_text() == SRC_CHANGED, f"Unexpected result for {file}"
+
+
+def test_complains_when_no_paths(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as ei:
+        main([])
+    assert ei.value.code == 2
+    assert "the following arguments are required" in capsys.readouterr().err


### PR DESCRIPTION
Would crash with `commonpath() arg is an empty sequence` otherwise.