### PR TITLE
Compute default excludes relative to original path

### DIFF
--- a/auto_walrus.py
+++ b/auto_walrus.py
@@ -382,7 +382,7 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover
                 for p in path.rglob("*")
                 if re.search(args.files, p.as_posix(), re.VERBOSE)
                 and not re.search(args.exclude, p.as_posix(), re.VERBOSE)
-                and not re.search(EXCLUDES, p.as_posix())
+                and not re.search(EXCLUDES, p.relative_to(path).as_posix())
                 and p.suffix == ".py"
             )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ filterwarnings = [
   'ignore:distutils Version classes are deprecated:DeprecationWarning',
 ]
 xfail_strict = true
-markers = ["config_content"]
+markers = ["config_content", "project_dir_name"]
 
 [tool.coverage.run]
 plugins = ["covdefaults"]


### PR DESCRIPTION
Otherwise files in e.g. `~/build/myproject/...` will never be read. (Can you guess where my projects are, for historical reasons, stored?)

Basically like https://github.com/astral-sh/ruff/pull/2471.

