### PR TITLE
Add --unsafe

### DIFF
--- a/auto_walrus.py
+++ b/auto_walrus.py
@@ -34,6 +34,7 @@ EXCLUDES = (
 @dataclasses.dataclass
 class Config:
     line_length: int
+    unsafe: bool = False
 
 
 def name_lineno_coloffset_iterable(
@@ -199,6 +200,7 @@ def related_vars_are_unused(
 
 def visit_function_def(
     node: ast.FunctionDef,
+    config: Config,
 ) -> list[tuple[Token, Token]]:
     names = set()
     assignments: set[Token] = set()
@@ -210,7 +212,7 @@ def visit_function_def(
     related_vars: dict[str, list[Token]] = {}
     in_body_vars: dict[Token, set[Token]] = {}
 
-    for _node in node.body:
+    for _node in ast.walk(node) if config.unsafe else node.body:
         if isinstance(_node, ast.Assign):
             process_assign(_node, assignments, related_vars)
         elif isinstance(_node, ast.If):
@@ -272,7 +274,7 @@ def auto_walrus(
     walruses = []
     for node in ast.walk(tree):
         if isinstance(node, ast.FunctionDef):
-            walruses.extend(visit_function_def(node))
+            walruses.extend(visit_function_def(node, config))
     lines_to_remove = []
     walruses = sorted(walruses, key=lambda x: (-x[1][1], -x[1][2]))
 
@@ -367,6 +369,11 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover
         required=False,
         default=r"^$",
     )
+    parser.add_argument(
+        "--unsafe",
+        action="store_true",
+        help="Also process if statements inside other blocks (like for loops)",
+    )
     # black formatter's default
     parser.add_argument("--line-length", type=int, default=88)
     args = parser.parse_args(argv)
@@ -379,7 +386,7 @@ def main(argv: Sequence[str] | None = None) -> int:  # pragma: no cover
 
     ret = 0
 
-    config = Config(line_length=args.line_length)
+    config = Config(line_length=args.line_length, unsafe=args.unsafe)
     for path in paths:
         if path.is_file():
             filepaths = iter((path,))

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -7,6 +7,7 @@ from typing import Tuple
 
 import pytest
 
+from auto_walrus import Config
 from auto_walrus import auto_walrus
 from auto_walrus import main
 
@@ -127,6 +128,20 @@ def test_rewrite(src: str, expected: str) -> None:
 def test_noop(src: str) -> None:
     ret = auto_walrus(src, Config(line_length=40))
     assert ret is None
+
+
+@pytest.mark.parametrize(
+    ("src", "expected"),
+    [
+        (
+            'def foo(data):\n    if True:\n        foo = data.get("blah")\n        if foo:\n            return foo\n    return data',
+            'def foo(data):\n    if True:\n        if (foo := data.get("blah")):\n            return foo\n    return data',
+        ),
+    ],
+)
+def test_rewrite_unsafe(src: str, expected: str) -> None:
+    ret = auto_walrus(src, Config(line_length=88, unsafe=True))
+    assert ret == expected
 
 
 ProjectDirT = Tuple[pathlib.Path, List[pathlib.Path]]


### PR DESCRIPTION
Applies transformations that might be wrong and need human eyes to verify.

Right now this means looking at assignments etc. also within sub-scopes, and we can't currently verify whether those are "safe".